### PR TITLE
postInfo length 및 fecth 문제 해결 & signup 및 forget Password 그리고 방 수정하기 다시 복구 

### DIFF
--- a/src/@core/Header/Desktop/Header.tsx
+++ b/src/@core/Header/Desktop/Header.tsx
@@ -88,7 +88,7 @@ const Header = () => {
                 </IconButton>
               </span>
               <IconButton>
-                <Link href="/Profile/Me">
+                <Link href="/profile/me">
                   {/* style={styles.profile} */}
                   <PersonIcon />
                 </Link>

--- a/src/@shared/components/FetchList/FetchList.ts
+++ b/src/@shared/components/FetchList/FetchList.ts
@@ -130,18 +130,20 @@ async function FetchReservation(
 
 async function FetchReservationByPostKey(
   setReservationInfo: Dispatch<SetStateAction<Reservation[]>>,
-  reservationInfo: Reservation[],
   postKey: string
 ) {
   const URL = `${process.env.NEXT_PUBLIC_BACKEND_URL}/reservation/post?key=${postKey}`;
 
-  const json: Reservation[] = await fetch(URL, headerOptions("GET"))
-    .then(notFoundError)
-    .catch(raiseError("FetchReservationByPostKey"));
-  setReservationInfo(json);
+  const getRequestInfo = async () => {
+    const json: Reservation[] = await fetch(URL, headerOptions("GET"))
+      .then(notFoundError)
+      .catch(raiseError("FetchReservationByPostKey"));
+    setReservationInfo(json);
+  };
 
-  const reservation = Array.from(reservationInfo);
-  return reservation;
+  useEffect(() => {
+    getRequestInfo();
+  }, []);
 }
 
 async function FetchDeleteReservation(keyNum: number) {

--- a/src/@shared/components/FetchList/FetchList.ts
+++ b/src/@shared/components/FetchList/FetchList.ts
@@ -74,15 +74,19 @@ async function FetchGetPost(
   userId: string,
   setPostInfo: Dispatch<SetStateAction<Post[]>>
 ) {
-  const URL = `${process.env.NEXT_PUBLIC_BACKEND_URL}/user/post/${userId}`;
+  const GetURL = `${process.env.NEXT_PUBLIC_BACKEND_URL}/user/post/${userId}`;
   const getPostInfo = async () => {
-    const json: Post[] = await fetch(URL, headerOptions("GET"))
+    await fetch(GetURL, headerOptions("GET"))
       .then(notFoundError)
+      .then((res) => {
+        console.log(userId);
+        setPostInfo(res);
+      })
       .catch(raiseError("FetchGetPost"));
-    setPostInfo(json);
   };
-
-  getPostInfo();
+  useEffect(() => {
+    getPostInfo();
+  }, [userId]);
 }
 
 async function FetchUploadPost(formData: FormData) {

--- a/src/@shared/components/FetchList/FetchList.ts
+++ b/src/@shared/components/FetchList/FetchList.ts
@@ -150,7 +150,7 @@ async function FetchDeleteReservation(keyNum: number) {
   fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/reservation`, {
     ...headerOptions("DELETE"),
     body: JSON.stringify({
-      key: keyNum,
+      key: String(keyNum),
     }),
   })
     .then(notFoundError)

--- a/src/@shared/components/Popup/Popup.tsx
+++ b/src/@shared/components/Popup/Popup.tsx
@@ -1484,8 +1484,14 @@ export const PostEditDialog = (post: { post: Post }) => {
   } = inputs;
 
   const onChange: (event: Event, value: number | number[]) => void = (e) => {
-    if (!e.target) return;
-    // setInputs({ ...inputs, [e.target.name]: e.target.value });
+    if (!e.currentTarget) return;
+
+    setInputs({
+      ...inputs,
+      [(e.currentTarget as HTMLInputElement).name]: (
+        e.currentTarget as HTMLInputElement
+      ).value,
+    });
   };
   const onClick = async () => {
     const formData = makeFormData();
@@ -1534,7 +1540,6 @@ export const PostEditDialog = (post: { post: Post }) => {
 
   return (
     <>
-      <DialogTitle></DialogTitle>
       <DialogContent sx={{ width: "500px" }} className="text-center">
         {/* <p>
             --------------추후 슬라이더로 변경 (현재는 스크롤)---------------

--- a/src/@shared/components/Popup/Popup.tsx
+++ b/src/@shared/components/Popup/Popup.tsx
@@ -71,6 +71,7 @@ import { guestInfoPopUpStore } from "@store/GuestInfoStore";
 import { CustomWindow, RequestRoom, Room } from "@app/RoomType";
 import { RequestForm } from "@app/RequestType";
 import { Post } from "@app/PostType";
+import Link from "next/link";
 
 export function DialogForm({
   name = "",
@@ -949,9 +950,9 @@ export function LoginDialog() {
               <div className="mt-2 flex items-center justify-between">
                 <s.Label htmlFor="password">Password</s.Label>
                 <div className="text-sm">
-                  {/*<s.PolicyText href="/resetpassword">
-                    Forgot password?
-  </s.PolicyText>*/}
+                  <Link href="/resetpassword">
+                    <s.PolicyText>Forgot password?</s.PolicyText>
+                  </Link>
                 </div>
               </div>
               <div className="mt-2">
@@ -970,13 +971,14 @@ export function LoginDialog() {
             </s.NormalButton>
           </div>
           <div className="text-sm">
-            {/*<s.PolicyText
-              className="mt-2 ml-1 text-m font-bold"
-              href="#"
-              onClick={signUpHandled}
-            >
-              회원가입
-            </s.PolicyText>*/}
+            <Link href="#">
+              <s.PolicyText
+                className="mt-2 ml-1 text-m font-bold"
+                onClick={signUpHandled}
+              >
+                회원가입
+              </s.PolicyText>
+            </Link>
           </div>
         </DialogContent>
         <s.Horizon />

--- a/src/@shared/components/RoomInfo/ImageCarousel.js
+++ b/src/@shared/components/RoomInfo/ImageCarousel.js
@@ -1,4 +1,4 @@
-import * as RS from '@shared/components/styles/RoomInfo.styles.js';
+import * as RS from '@shared/styles/RoomInfo.styles.js';
 import { Carousel } from '@material-tailwind/react';
 
 export function ImageCarousel({ children }) {

--- a/src/@shared/components/verifyComponents/Email.tsx
+++ b/src/@shared/components/verifyComponents/Email.tsx
@@ -1,5 +1,10 @@
 import { ChangeEvent, useState } from "react";
-import { Alert, FailAlert } from "../StaticComponents/StaticComponents";
+import {
+  Alert,
+  FailAlert,
+  notFoundError,
+  raiseError,
+} from "../StaticComponents/StaticComponents";
 import {
   FetchResetPassword,
   FetchVerifyEmail,
@@ -52,60 +57,13 @@ export function VerifyEmailComponents({
         tokenKey: email,
         verifyToken: numberState,
       })
-        .then((response) => {
-          if (!response.ok) {
-            // create error object and reject if not a 2xx response code
-            const err = new Error("HTTP status code: " + response.status);
-            // err.response = response;
-            // err.status = response.status;
-            setFailState(true);
-            setTimeout(() => {
-              setFailState(false);
-            }, 5000);
-          } else {
-            setSuccessState(true);
-            setTimeout(() => {
-              setSuccessState(false);
-            }, 5000);
-          }
-        })
-        .catch((err) => {
-          setFailState(true);
-          setTimeout(() => {
-            setFailState(false);
-          }, 5000);
-          console.log("Err", err);
-        });
+        .then((res) => notFoundError(res, true, setSuccessState))
+        .catch(raiseError("FetchVerifyUser", true, setFailState));
     } else if (purpose === "resetpassword") {
       FetchResetPassword(userId, email, numberState)
-        .then((response) => {
-          console.log(response);
-          if (!response.ok) {
-            // create error object and reject if not a 2xx response code
-            const err = new Error("HTTP status code: " + response.status);
-            // err.response = response;
-            // err.status = response.status;
-            setFailState(true);
-            setTimeout(() => {
-              setFailState(false);
-            }, 5000);
-          } else {
-            setSuccessState(true);
-            setTimeout(() => {
-              setSuccessState(false);
-            }, 5000);
-            setVerifyPasswordEmail();
-            console.log(verifyPasswordEmail);
-          }
-        })
-        .catch((err) => {
-          setFailState(true);
-          setTimeout(() => {
-            setFailState(false);
-          }, 5000);
-
-          console.log("Err", err);
-        });
+        .then((res) => notFoundError(res, true, setSuccessState))
+        .then(() => setVerifyPasswordEmail())
+        .catch(raiseError("FetchVerifyUser", true, setFailState));
     }
   };
   return (

--- a/src/app/profile/me/components/Blocks/PostSummaryBlock.tsx
+++ b/src/app/profile/me/components/Blocks/PostSummaryBlock.tsx
@@ -13,6 +13,8 @@ import { MouseEventHandler, useState } from "react";
 import { Room } from "@/app/RoomType";
 import { Post } from "@/app/PostType";
 import { useRouter } from "next/navigation";
+import { PostEditDialog } from "@shared/components/Popup/Popup";
+import { PostEditRoomDialog } from "../Dialog/PostEditDialog";
 
 export function PostSummaryBlock({
   room,
@@ -80,7 +82,6 @@ export function PostSummaryBlock({
     //   room: room.Post,
     // });
   };
-
   return (
     <div className="flex grid grid-cols-5 mt-4 ml-4">
       <div className="w-46 h-26">
@@ -154,6 +155,12 @@ export function PostSummaryBlock({
                 requestDialogShow={requestDialogShow}
                 onClick={onClick}
                 requestKey={room.requestIDs}
+              />
+
+              <PostEditRoomDialog
+                room={room}
+                editRoomDialogShow={editRoomDialogShow}
+                onClick={onClick}
               />
             </>
           )}

--- a/src/app/profile/me/components/Blocks/ReservationSummaryBlock.tsx
+++ b/src/app/profile/me/components/Blocks/ReservationSummaryBlock.tsx
@@ -70,7 +70,7 @@ export function ReservationSummaryBlock({ room }: { room: Reservation }) {
             clickHandler={clickHandler}
             checkState={checkState}
             checkHandled={setCheckState}
-            key={room.key}
+            roomKey={room.key}
           />
         </div>
       </div>

--- a/src/app/profile/me/components/Dialog/CancleReservationDialog.tsx
+++ b/src/app/profile/me/components/Dialog/CancleReservationDialog.tsx
@@ -13,13 +13,13 @@ export function CancleReservationDialog({
   clickHandler,
   checkState,
   checkHandled,
-  key,
+  roomKey,
 }: {
   popupState: boolean;
   clickHandler: React.MouseEventHandler<HTMLButtonElement>;
   checkState: boolean;
   checkHandled: React.Dispatch<React.SetStateAction<boolean>>;
-  key: number;
+  roomKey: number;
 }) {
   return (
     <DialogForm
@@ -53,7 +53,7 @@ export function CancleReservationDialog({
             <form>
               <DeleteButton
                 onClick={() => {
-                  FetchDeleteReservation(key);
+                  FetchDeleteReservation(roomKey);
                 }}
               >
                 취소하기

--- a/src/app/profile/me/components/Dialog/PostEditDialog.tsx
+++ b/src/app/profile/me/components/Dialog/PostEditDialog.tsx
@@ -1,19 +1,20 @@
 import { Post } from "@/app/PostType";
 import { DialogForm, PostEditDialog } from "@shared/components/Popup/Popup";
+import { MouseEventHandler } from "react";
 
 export const PostEditRoomDialog = ({
   editRoomDialogShow,
-  onChange,
+  onClick,
   room,
 }: {
   editRoomDialogShow: boolean;
-  onChange: React.ChangeEvent<HTMLInputElement>;
+  onClick: MouseEventHandler<HTMLButtonElement>;
   room: Post;
 }) => {
   return (
     <DialogForm
       openState={editRoomDialogShow}
-      handleClose={onChange}
+      handleClose={onClick}
       name="editRoomDialogShow"
       render={() => (
         <label

--- a/src/app/profile/me/components/Dialog/PostRequestDialog.tsx
+++ b/src/app/profile/me/components/Dialog/PostRequestDialog.tsx
@@ -7,9 +7,9 @@ import React, {
   SetStateAction,
   useState,
 } from "react";
-import { PostRequest } from "../Info/GetPostRequest";
 import { RequestForm } from "@app/RequestType";
 import { RequestRoom } from "@app/RoomType";
+import { PostRequest } from "../Info/GetPostRequest";
 
 export function PostRequestDialog({
   requestDialogShow,

--- a/src/app/profile/me/components/Info/ReservationByPostKeyInfo.tsx
+++ b/src/app/profile/me/components/Info/ReservationByPostKeyInfo.tsx
@@ -21,7 +21,7 @@ export function ReservationByPostKeyInfo({
     [] as Reservation[]
   );
 
-  FetchReservationByPostKey(setReservationInfo, reservationInfo, requestKey);
+  FetchReservationByPostKey(setReservationInfo, requestKey);
   return (
     <div className="mb-4">
       <SecondHead>예약 현황</SecondHead>

--- a/src/app/profile/me/components/Info/ReservationInfo.tsx
+++ b/src/app/profile/me/components/Info/ReservationInfo.tsx
@@ -11,7 +11,9 @@ export function ReservationInfo() {
     <div className="mb-4">
       <SecondHead>예약 현황</SecondHead>
       {(reservationInfo && reservationInfo.length) > 0 ? (
-        reservationInfo.map((res, index) => <ReservationSummaryBlock room={res} />)
+        reservationInfo.map((res, index) => (
+          <ReservationSummaryBlock key={index} room={res} />
+        ))
       ) : (
         <NormalText>예약이 아직 없습니다.</NormalText>
       )}

--- a/src/app/profile/me/components/UserProfile/PostListComponent.tsx
+++ b/src/app/profile/me/components/UserProfile/PostListComponent.tsx
@@ -21,7 +21,6 @@ function PostListComponent({
   guestMode?: boolean;
 }) {
   const [postInfo, setPostInfo] = useState<Post[]>([]);
-  console.log(typeof userId, postInfo);
 
   FetchGetPost(userId, setPostInfo);
   const { setPostPopUpState } = guestInfoPopUpStore((state) => ({

--- a/src/app/profile/me/components/UserProfile/PostListComponent.tsx
+++ b/src/app/profile/me/components/UserProfile/PostListComponent.tsx
@@ -9,9 +9,9 @@ import {
   priceToString,
 } from "@shared/components/StaticComponents/StaticComponents";
 import { FetchGetPost } from "@shared/components/FetchList/FetchList";
-import { PostSummaryBlock } from "../Blocks/PostSummaryBlock";
 import { Post } from "@app/PostType";
 import { guestInfoPopUpStore } from "@store/GuestInfoStore";
+import { PostSummaryBlock } from "../Blocks/PostSummaryBlock";
 
 function PostListComponent({
   userId,
@@ -21,6 +21,8 @@ function PostListComponent({
   guestMode?: boolean;
 }) {
   const [postInfo, setPostInfo] = useState<Post[]>([]);
+  console.log(typeof userId, postInfo);
+
   FetchGetPost(userId, setPostInfo);
   const { setPostPopUpState } = guestInfoPopUpStore((state) => ({
     setPostPopUpState: state.setPostPopUpState,

--- a/src/app/profile/me/page.tsx
+++ b/src/app/profile/me/page.tsx
@@ -8,11 +8,9 @@ import { UserPrivateComponent } from "./components/UserProfile/UserPrivateCompon
 import { Horizon, Wrapper } from "@shared/styles/Public.styles";
 import { ReservationInfo } from "./components/Info/ReservationInfo";
 import { PostListComponent } from "./components/UserProfile/PostListComponent";
-import { FetchGetMyUser } from "@shared/components/FetchList/FetchList";
 import { UserBaseComponent } from "./components/UserImageProfile";
 import { UserForm } from "@app/UserType";
 import { useUserInfoStore } from "@store/UserInfoStore";
-
 function GuestInfo() {
   const { userInfo } = useUserInfoStore();
   // useTitle('프로필 | ItHome');

--- a/src/app/roominfo/[roomKey]/page.tsx
+++ b/src/app/roominfo/[roomKey]/page.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { Dialog, DialogContent } from "@mui/material";
 import React, { useState, useEffect } from "react";
 import { useParams } from "next/navigation";


### PR DESCRIPTION
- [x] 기능

  - [x] postInfo length 문제
  - [x] postInfo 너무 많은 fetch 해결
  - [x] Signup & forgetPassword 다시 돌려놨습니다.
  - [x] 방수정하기도 다시 되돌렸습니다 

# 개요

postInfo length 문제
postInfo 너무 많은 fetch 해결
위 두문제 해결했습니다.
또한 Signup & forgetPassword 다시 돌려놨습니다.
방수정하기도 다시 되돌렸습니다

## Front

- 솔루션은 url에 userId가 return이 되지 않았는데 미리 시작하여 fetch가
- user/post/undefined로 결정된겁니다. 그래서 userId가 들어오면 다시 fetch하도록 했습니다. useEffect를 사용하니 많은 fetch 문제도 자동으로 해결됐지만 그래도 지금 많은 fetch가 일어납니다.
- Signup & forgetPassword 다시 돌려놓음
- 방수정하기도 다시 되돌렸음
## To Reviewers

- @ussr1285 코드 확인 부탁드립니다. 오류 해결완료했습니다.
- @Turtle-Hwan @bagger3025 front에 고질적인 문제중 하나가 fetch 횟수가 너무 많습니다. useEffect를 이용해 줄이는 방법을 알아봐야할 거 같습니다.